### PR TITLE
Bradley Beal signed

### DIFF
--- a/data/contract_types.csv
+++ b/data/contract_types.csv
@@ -42,6 +42,7 @@ Bilal Coulibaly,https://www.spotrac.com/nba/player/_/id/82317/bilal-coulibaly,bi
 Bobby Portis,https://www.spotrac.com/nba/player/_/id/17850/bobby-portis,bobby-portis,Bird Rights,"Round 1 (#22 overall), 2015"
 Bogdan Bogdanovic,https://www.spotrac.com/nba/player/_/id/15379/bogdan-bogdanovic,bogdan-bogdanovic,Minimum,"Round 1 (#27 overall), 2014"
 Bogoljub Marković,https://www.spotrac.com/nba/player/_/id/99260/bogoljub-markovi%C4%87,bogoljub-markovic,Second Round Exception,"Round 2 (#47 overall), 2025"
+Bradley Beal,https://www.spotrac.com/nba/player/_/id/10811/bradley-beal,bradley-beal,Non-Bird Rights,"Round 1 (#3 overall), 2012"
 Branden Carlson,https://www.spotrac.com/nba/player/_/id/94490/branden-carlson,branden-carlson,Minimum,
 Brandin Podziemski,https://www.spotrac.com/nba/player/_/id/84438/brandin-podziemski,brandin-podziemski,Rookie Scale Exception,"Round 1 (#19 overall), 2023"
 Brandon Ingram,https://www.spotrac.com/nba/player/_/id/20207/brandon-ingram,brandon-ingram,Bird Rights,"Round 1 (#2 overall), 2016"

--- a/data/spotrac_contracts.csv
+++ b/data/spotrac_contracts.csv
@@ -48,6 +48,7 @@ Blake Hinson,https://www.spotrac.com/nba/player/_/id/94488/blake-hinson,blake-hi
 Bobby Portis,https://www.spotrac.com/nba/player/_/id/17850/bobby-portis,bobby-portis,Miami Heat,https://www.spotrac.com/nba/miami-heat/yearly,PF,31,$14521414,$15597074,UFA,,,Robert
 Bogdan Bogdanovic,https://www.spotrac.com/nba/player/_/id/15379/bogdan-bogdanovic,bogdan-bogdanovic,Houston Rockets,https://www.spotrac.com/nba/houston-rockets/yearly,SG,34,$2449421,UFA,,,,
 Bogoljub Marković,https://www.spotrac.com/nba/player/_/id/99260/bogoljub-markovi%C4%87,bogoljub-markovic,Milwaukee Bucks,https://www.spotrac.com/nba/milwaukee-bucks/yearly,PF,21,$1357763,$2294370,$2694363,$2918152,UFA,
+Bradley Beal,https://www.spotrac.com/nba/player/_/id/10811/bradley-beal,bradley-beal,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,SG,33,$6424800,,UFA,,,
 Branden Carlson,https://www.spotrac.com/nba/player/_/id/94490/branden-carlson,branden-carlson,Portland Trail Blazers,https://www.spotrac.com/nba/portland-trail-blazers/yearly,C,27,$2449421,RFA,,,,
 Brandin Podziemski,https://www.spotrac.com/nba/player/_/id/84438/brandin-podziemski,brandin-podziemski,Golden State Warriors,https://www.spotrac.com/nba/golden-state-warriors/yearly,SG,23,$5679459,RFA,,,,Sam
 Brandon Ingram,https://www.spotrac.com/nba/player/_/id/20207/brandon-ingram,brandon-ingram,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,SF,29,$40000000,$41904762,UFA,,,Brandon
@@ -155,7 +156,6 @@ Elijah Harkless,https://www.spotrac.com/nba/player/_/id/95564/elijah-harkless,el
 Emanuel Sharp,https://www.spotrac.com/nba/player/_/id/108434/emanuel-sharp,emanuel-sharp,Sacramento Kings,https://www.spotrac.com/nba/sacramento-kings/yearly,PG,22,$1357763,$2294370,$2694363,RFA,,
 Enrique Freeman,https://www.spotrac.com/nba/player/_/id/93958/enrique-freeman,enrique-freeman,Minnesota Timberwolves,https://www.spotrac.com/nba/minnesota-timberwolves/yearly,PF,26,Two-Way,,,,,
 Ernest Udeh Jr.,https://www.spotrac.com/nba/player/_/id/108828/ernest-udeh-jr,ernest-udeh,Cleveland Cavaliers,https://www.spotrac.com/nba/cleveland-cavaliers/yearly,C,23,Two-Way,,,,,
-Ethan Thompson,https://www.spotrac.com/nba/player/_/id/74413/ethan-thompson,ethan-thompson,Indiana Pacers,https://www.spotrac.com/nba/indiana-pacers/yearly,SG,27,Two-Way,,,,,
 Evan Mobley,https://www.spotrac.com/nba/player/_/id/74110/evan-mobley,evan-mobley,Cleveland Cavaliers,https://www.spotrac.com/nba/cleveland-cavaliers/yearly,PF,25,$50105628,$53817156,$57528684,$61240212,UFA,Will
 Felix Okpara,https://www.spotrac.com/nba/player/_/id/108435/felix-okpara,felix-okpara,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,C,22,Two-Way,,,,,
 Franz Wagner,https://www.spotrac.com/nba/player/_/id/74115/franz-wagner,franz-wagner,Orlando Magic,https://www.spotrac.com/nba/orlando-magic/yearly,SF,25,$41754690,$44847630,$47940570,$51033510,UFA,Sam


### PR DESCRIPTION
Bradley Beal (SG) - Agreed to a 2 year $13.17 million contract with LA Clippers (LAC) - includes 2027-28 Club Option