### PR TITLE
Added DeMar DeRozan, Klay Thompson

### DIFF
--- a/data/contract_types.csv
+++ b/data/contract_types.csv
@@ -107,6 +107,7 @@ De'Andre Hunter,https://www.spotrac.com/nba/player/_/id/31561/deandre-hunter,dea
 DeAndre Jordan,https://www.spotrac.com/nba/player/_/id/6117/deandre-jordan,deandre-jordan,Minimum,"Round 2 (#35 overall), 2008"
 De'Anthony Melton,https://www.spotrac.com/nba/player/_/id/27012/deanthony-melton,deanthony-melton,Taxpayer MLE,"Round 2 (#46 overall), 2018"
 Dejounte Murray,https://www.spotrac.com/nba/player/_/id/20234/dejounte-murray,dejounte-murray,Bird Rights,"Round 1 (#29 overall), 2016"
+DeMar DeRozan,https://www.spotrac.com/nba/player/_/id/6327/demar-derozan,demar-derozan,Minimum,"Round 1 (#9 overall), 2009"
 Deni Avdija,https://www.spotrac.com/nba/player/_/id/70651/deni-avdija,deni-avdija,Bird Rights,"Round 1 (#9 overall), 2020"
 Dennis Schröder,https://www.spotrac.com/nba/player/_/id/13330/dennis-schr%C3%B6der,dennis-schroder,Non-Taxpayer MLE,"Round 1 (#17 overall), 2013"
 Dereck Lively II,https://www.spotrac.com/nba/player/_/id/82272/dereck-lively-ii,dereck-lively,Rookie Scale Exception,"Round 1 (#12 overall), 2023"
@@ -185,6 +186,7 @@ Jamal Cain,https://www.spotrac.com/nba/player/_/id/78584/jamal-cain,jamal-cain,M
 Jamal Murray,https://www.spotrac.com/nba/player/_/id/20212/jamal-murray,jamal-murray,Bird Rights,"Round 1 (#7 overall), 2016"
 Jamal Shead,https://www.spotrac.com/nba/player/_/id/93955/jamal-shead,jamal-shead,Second Round Exception,"Round 2 (#45 overall), 2024"
 Jamaree Bouyea,https://www.spotrac.com/nba/player/_/id/78578/jamaree-bouyea,jamaree-bouyea,Minimum,
+James Harden,https://www.spotrac.com/nba/player/_/id/6312/james-harden,james-harden,Bird Rights,"Round 1 (#3 overall), 2009"
 Jamison Battle,https://www.spotrac.com/nba/player/_/id/95121/jamison-battle,jamison-battle,Non-Taxpayer MLE,"Aaron Klevan, Joe Smith (THE·TEAM)"
 Jarace Walker,https://www.spotrac.com/nba/player/_/id/82201/jarace-walker,jarace-walker,Rookie Scale Exception,"Round 1 (#8 overall), 2023"
 Jared McCain,https://www.spotrac.com/nba/player/_/id/91760/jared-mccain,jared-mccain,Rookie Scale Exception,"Round 1 (#16 overall), 2024"
@@ -286,6 +288,7 @@ Luka Doncic,https://www.spotrac.com/nba/player/_/id/26969/luka-doncic,luka-donci
 Luka Garza,https://www.spotrac.com/nba/player/_/id/74159/luka-garza,luka-garza,Minimum,"Round 2 (#52 overall), 2021"
 Luke Kennard,https://www.spotrac.com/nba/player/_/id/23607/luke-kennard,luke-kennard,Taxpayer MLE,"Round 1 (#12 overall), 2017"
 Luke Kornet,https://www.spotrac.com/nba/player/_/id/23670/luke-kornet,luke-kornet,Non-Taxpayer MLE,"Undrafted, NYK, 2017"
+Malachi Smith,https://www.spotrac.com/nba/player/_/id/86052/malachi-smith,malachi-smith,Minimum,
 Malik Monk,https://www.spotrac.com/nba/player/_/id/23606/malik-monk,malik-monk,Early Bird Rights,"Round 1 (#11 overall), 2017"
 Marcus Sasser,https://www.spotrac.com/nba/player/_/id/84442/marcus-sasser,marcus-sasser,Rookie Scale Exception,"Round 1 (#25 overall), 2023"
 Marcus Smart,https://www.spotrac.com/nba/player/_/id/15358/marcus-smart,marcus-smart,Non-Taxpayer MLE,"Round 1 (#6 overall), 2014"
@@ -354,6 +357,7 @@ Paul Reed,https://www.spotrac.com/nba/player/_/id/70700/paul-reed,paul-reed,Earl
 Payton Pritchard,https://www.spotrac.com/nba/player/_/id/70668/payton-pritchard,payton-pritchard,Bird Rights,"Round 1 (#26 overall), 2020"
 Pelle Larsson,https://www.spotrac.com/nba/player/_/id/91787/pelle-larsson,pelle-larsson,Second Round Exception,"Round 2 (#44 overall), 2024"
 Pete Nance,https://www.spotrac.com/nba/player/_/id/86006/pete-nance,pete-nance,Minimum,"Kieran Piller, Mark Bartelstein"
+Peyton Watson,https://www.spotrac.com/nba/player/_/id/78138/peyton-watson,peyton-watson,Bird Rights,"Round 1 (#30 overall), 2022"
 PJ Washington,https://www.spotrac.com/nba/player/_/id/31569/pj-washington,pj-washington,Bird Rights,"Round 1 (#12 overall), 2019"
 Precious Achiuwa,https://www.spotrac.com/nba/player/_/id/70662/precious-achiuwa,precious-achiuwa,Bi-Annual,"Round 1 (#20 overall), 2020"
 Quentin Grimes,https://www.spotrac.com/nba/player/_/id/74132/quentin-grimes,quentin-grimes,Cap Space,"Round 1 (#25 overall), 2021"

--- a/data/contract_types.csv
+++ b/data/contract_types.csv
@@ -47,6 +47,7 @@ Branden Carlson,https://www.spotrac.com/nba/player/_/id/94490/branden-carlson,br
 Brandin Podziemski,https://www.spotrac.com/nba/player/_/id/84438/brandin-podziemski,brandin-podziemski,Rookie Scale Exception,"Round 1 (#19 overall), 2023"
 Brandon Ingram,https://www.spotrac.com/nba/player/_/id/20207/brandon-ingram,brandon-ingram,Bird Rights,"Round 1 (#2 overall), 2016"
 Brandon Miller,https://www.spotrac.com/nba/player/_/id/82197/brandon-miller,brandon-miller,Rookie Scale Exception,"Round 1 (#2 overall), 2023"
+Brandon Williams,https://www.spotrac.com/nba/player/_/id/75136/brandon-williams,brandon-williams,Minimum,Sam Goldfeder
 Brayden Burries,https://www.spotrac.com/nba/player/_/id/107926/brayden-burries,brayden-burries,Rookie Scale Exception,"Round 1 (#10 overall), 2026"
 Brice Sensabaugh,https://www.spotrac.com/nba/player/_/id/82213/brice-sensabaugh,brice-sensabaugh,Rookie Scale Exception,"Round 1 (#28 overall), 2023"
 Bronny James,https://www.spotrac.com/nba/player/_/id/92960/bronny-james,bronny-james,Second Round Exception,"Round 2 (#55 overall), 2024"
@@ -261,7 +262,7 @@ Keyonte George,https://www.spotrac.com/nba/player/_/id/82209/keyonte-george,keyo
 Khaman Maluach,https://www.spotrac.com/nba/player/_/id/98606/khaman-maluach,khaman-maluach,Rookie Scale Exception,"Round 1 (#10 overall), 2025"
 Khris Middleton,https://www.spotrac.com/nba/player/_/id/10864/khris-middleton,khris-middleton,Bird Rights,"Round 2 (#39 overall), 2012"
 Kingston Flemings,https://www.spotrac.com/nba/player/_/id/107923/kingston-flemings,kingston-flemings,Rookie Scale Exception,"Round 1 (#8 overall), 2026"
-Klay Thompson,https://www.spotrac.com/nba/player/_/id/8062/klay-thompson,klay-thompson,Bird Rights,"Round 1 (#11 overall), 2011"
+Klay Thompson,https://www.spotrac.com/nba/player/_/id/8062/klay-thompson,klay-thompson,Non-Taxpayer MLE,"Round 1 (#11 overall), 2011"
 Koa Peat,https://www.spotrac.com/nba/player/_/id/107938/koa-peat,koa-peat,Rookie Scale Exception,"Round 1 (#30 overall), 2026"
 Kobe Bufkin,https://www.spotrac.com/nba/player/_/id/82271/kobe-bufkin,kobe-bufkin,Minimum,"Round 1 (#15 overall), 2023"
 Kobe Sanders,https://www.spotrac.com/nba/player/_/id/99262/kobe-sanders,kobe-sanders,Non-Bird Rights,"Round 2 (#50 overall), 2025"

--- a/data/spotrac_contracts.csv
+++ b/data/spotrac_contracts.csv
@@ -125,6 +125,7 @@ De'Andre Hunter,https://www.spotrac.com/nba/player/_/id/31561/deandre-hunter,dea
 DeAndre Jordan,https://www.spotrac.com/nba/player/_/id/6117/deandre-jordan,deandre-jordan,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,C,38,$3876529,$4070355,UFA,,,
 De'Anthony Melton,https://www.spotrac.com/nba/player/_/id/27012/deanthony-melton,deanthony-melton,Golden State Warriors,https://www.spotrac.com/nba/golden-state-warriors/yearly,SG,28,$6064000,$6367200,UFA,,,
 Dejounte Murray,https://www.spotrac.com/nba/player/_/id/20234/dejounte-murray,dejounte-murray,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,PG,30,$32785071,$30751504,UFA,,,Kyle
+DeMar DeRozan,https://www.spotrac.com/nba/player/_/id/6327/demar-derozan,demar-derozan,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,SF,37,$2449421,UFA,,,,
 Deni Avdija,https://www.spotrac.com/nba/player/_/id/70651/deni-avdija,deni-avdija,Portland Trail Blazers,https://www.spotrac.com/nba/portland-trail-blazers/yearly,SF,26,$13125000,$11875000,UFA,,,Brandon
 Dennis Schröder,https://www.spotrac.com/nba/player/_/id/13330/dennis-schr%C3%B6der,dennis-schroder,Charlotte Hornets,https://www.spotrac.com/nba/charlotte-hornets/yearly,PG,33,$14809200,$15514400,UFA,,,
 Dereck Lively II,https://www.spotrac.com/nba/player/_/id/82272/dereck-lively-ii,dereck-lively,Dallas Mavericks,https://www.spotrac.com/nba/dallas-mavericks/yearly,C,22,$7239131,RFA,,,,Zack
@@ -309,7 +310,6 @@ Khaman Maluach,https://www.spotrac.com/nba/player/_/id/98606/khaman-maluach,kham
 Khris Middleton,https://www.spotrac.com/nba/player/_/id/10864/khris-middleton,khris-middleton,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,SF,35,$5591122,$5870678,$6150234,UFA,,
 Kingston Flemings,https://www.spotrac.com/nba/player/_/id/107923/kingston-flemings,kingston-flemings,Atlanta Hawks,https://www.spotrac.com/nba/atlanta-hawks/yearly,PG,20,$7348680,$7716120,$8083680,$10282441,RFA,
 K.J. Simpson,https://www.spotrac.com/nba/player/_/id/91788/kj-simpson,kj-simpson,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,PG,24,Two-Way,,,,,Kyle
-Klay Thompson,https://www.spotrac.com/nba/player/_/id/8062/klay-thompson,klay-thompson,Dallas Mavericks,https://www.spotrac.com/nba/dallas-mavericks/yearly,SG,36,$17460317,UFA,,,,
 Koa Peat,https://www.spotrac.com/nba/player/_/id/107938/koa-peat,koa-peat,Phoenix Suns,https://www.spotrac.com/nba/phoenix-suns/yearly,PF,20,$2926800,$3073080,$3219840,$5811811,RFA,
 Kobe Brown,https://www.spotrac.com/nba/player/_/id/84464/kobe-brown,kobe-brown,Indiana Pacers,https://www.spotrac.com/nba/indiana-pacers/yearly,PF,27,Two-Way,,,,,
 Kobe Bufkin,https://www.spotrac.com/nba/player/_/id/82271/kobe-bufkin,kobe-bufkin,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,PG,23,$0,,,,,

--- a/data/spotrac_contracts.csv
+++ b/data/spotrac_contracts.csv
@@ -71,7 +71,6 @@ Caleb Martin,https://www.spotrac.com/nba/player/_/id/32682/caleb-martin,caleb-ma
 Caleb Wilson,https://www.spotrac.com/nba/player/_/id/107920/caleb-wilson,caleb-wilson,Chicago Bulls,https://www.spotrac.com/nba/chicago-bulls/yearly,PF,20,$10683720,$11217960,$11752320,$14866685,RFA,
 Cam Spencer,https://www.spotrac.com/nba/player/_/id/93960/cam-spencer,cam-spencer,Memphis Grizzlies,https://www.spotrac.com/nba/memphis-grizzlies/yearly,SG,26,$2411090,$2616754,$2830685,UFA,,
 Cam Whitmore,https://www.spotrac.com/nba/player/_/id/82202/cam-whitmore,cam-whitmore,Cleveland Cavaliers,https://www.spotrac.com/nba/cleveland-cavaliers/yearly,SF,22,$5458310,RFA,,,,David
-Cam Whitmore,https://www.spotrac.com/nba/player/_/id/82202/cam-whitmore,cam-whitmore,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,SF,22,$5458310,RFA,,,,David
 Cameron Boozer,https://www.spotrac.com/nba/player/_/id/107919/cameron-boozer,cameron-boozer,Memphis Grizzlies,https://www.spotrac.com/nba/memphis-grizzlies/yearly,PF,19,$11849760,$12441840,$13034880,$16476089,RFA,
 Cameron Carr,https://www.spotrac.com/nba/player/_/id/107940/cameron-carr,cameron-carr,Los Angeles Lakers,https://www.spotrac.com/nba/los-angeles-lakers/yearly,SG,22,$3315360,$3481080,$3646800,$6378253,RFA,
 Cameron Christie,https://www.spotrac.com/nba/player/_/id/91777/cameron-christie,cameron-christie,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,SG,21,$2296271,$2486995,UFA,,,
@@ -128,7 +127,6 @@ De'Anthony Melton,https://www.spotrac.com/nba/player/_/id/27012/deanthony-melton
 Dejounte Murray,https://www.spotrac.com/nba/player/_/id/20234/dejounte-murray,dejounte-murray,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,PG,30,$32785071,$30751504,UFA,,,Kyle
 Deni Avdija,https://www.spotrac.com/nba/player/_/id/70651/deni-avdija,deni-avdija,Portland Trail Blazers,https://www.spotrac.com/nba/portland-trail-blazers/yearly,SF,26,$13125000,$11875000,UFA,,,Brandon
 Dennis Schröder,https://www.spotrac.com/nba/player/_/id/13330/dennis-schr%C3%B6der,dennis-schroder,Charlotte Hornets,https://www.spotrac.com/nba/charlotte-hornets/yearly,PG,33,$14809200,$15514400,UFA,,,
-Dennis Schröder,https://www.spotrac.com/nba/player/_/id/13330/dennis-schr%C3%B6der,dennis-schroder,Cleveland Cavaliers,https://www.spotrac.com/nba/cleveland-cavaliers/yearly,PG,33,$14809200,$15514400,UFA,,,
 Dereck Lively II,https://www.spotrac.com/nba/player/_/id/82272/dereck-lively-ii,dereck-lively,Dallas Mavericks,https://www.spotrac.com/nba/dallas-mavericks/yearly,C,22,$7239131,RFA,,,,Zack
 Derik Queen,https://www.spotrac.com/nba/player/_/id/98607/derik-queen,derik-queen,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,C,22,$5416080,$5673840,$8107918,RFA,,Hil
 Derrick Jones Jr.,https://www.spotrac.com/nba/player/_/id/21067/derrick-jones-jr,derrick-jones,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,SF,29,$10476190,UFA,,,,
@@ -281,7 +279,6 @@ Jrue Holiday,https://www.spotrac.com/nba/player/_/id/6316/jrue-holiday,jrue-holi
 Julian Champagnie,https://www.spotrac.com/nba/player/_/id/78268/julian-champagnie,julian-champagnie,San Antonio Spurs,https://www.spotrac.com/nba/san-antonio-spurs/yearly,SF,25,$15350000,$15000000,$14650000,UFA,,
 Julian Phillips,https://www.spotrac.com/nba/player/_/id/84444/julian-phillips,julian-phillips,Houston Rockets,https://www.spotrac.com/nba/houston-rockets/yearly,SF,23,$0,UFA,,,,
 Julian Reese,https://www.spotrac.com/nba/player/_/id/101322/julian-reese,julian-reese,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,F,23,Two-Way,,,,,
-Julian Reese,https://www.spotrac.com/nba/player/_/id/101322/julian-reese,julian-reese,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,F,23,Two-Way,,,,,
 Julian Strawther,https://www.spotrac.com/nba/player/_/id/84463/julian-strawther,julian-strawther,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,SF,24,$4826931,RFA,,,,
 Julius Randle,https://www.spotrac.com/nba/player/_/id/15359/julius-randle,julius-randle,Brooklyn Nets,https://www.spotrac.com/nba/brooklyn-nets/yearly,PF,32,$33333334,$35802468,UFA,,,Robert
 Justin Champagnie,https://www.spotrac.com/nba/player/_/id/74240/justin-champagnie,justin-champagnie,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,SF,25,$2667944,$3005085,UFA,,,Colin
@@ -356,7 +353,6 @@ Marvin Bagley III,https://www.spotrac.com/nba/player/_/id/26968/marvin-bagley-ii
 Matas Buzelis,https://www.spotrac.com/nba/player/_/id/91738/matas-buzelis,matas-buzelis,Chicago Bulls,https://www.spotrac.com/nba/chicago-bulls/yearly,SF,22,$5715360,$7584283,RFA,,,Andrew
 Matisse Thybulle,https://www.spotrac.com/nba/player/_/id/31577/matisse-thybulle,matisse-thybulle,Los Angeles Lakers,https://www.spotrac.com/nba/los-angeles-lakers/yearly,SG,29,$2449421,UFA,,,,
 Max Christie,https://www.spotrac.com/nba/player/_/id/78136/max-christie,max-christie,Dallas Mavericks,https://www.spotrac.com/nba/dallas-mavericks/yearly,SG,23,$8285714,$8857143,UFA,,,
-Max Strus,https://www.spotrac.com/nba/player/_/id/32411/max-strus,max-strus,Cleveland Cavaliers,https://www.spotrac.com/nba/cleveland-cavaliers/yearly,SG,30,$16660836,UFA,,,,Zack
 Max Strus,https://www.spotrac.com/nba/player/_/id/32411/max-strus,max-strus,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,SG,30,$16660836,UFA,,,,Zack
 Maxime Raynaud,https://www.spotrac.com/nba/player/_/id/98635/maxime-raynaud,maxime-raynaud,Sacramento Kings,https://www.spotrac.com/nba/sacramento-kings/yearly,C,23,$2150918,$2525901,RFA,,,BJ
 Meleek Thomas,https://www.spotrac.com/nba/player/_/id/107945/meleek-thomas,meleek-thomas,Cleveland Cavaliers,https://www.spotrac.com/nba/cleveland-cavaliers/yearly,SG,20,$1357763,$2294370,$2694363,$2918152,UFA,
@@ -493,7 +489,6 @@ Trayce Jackson-Davis,https://www.spotrac.com/nba/player/_/id/84443/trayce-jackso
 Tre Donaldson,https://www.spotrac.com/nba/player/_/id/108840/tre-donaldson,tre-donaldson,Miami Heat,https://www.spotrac.com/nba/miami-heat/yearly,G,23,Two-Way,,,,,
 Tre Johnson,https://www.spotrac.com/nba/player/_/id/98601/tre-johnson,tre-johnson,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,SG,20,$8649600,$9061680,$11490211,RFA,,Will
 Tre Jones,https://www.spotrac.com/nba/player/_/id/70683/tre-jones,tre-jones,Chicago Bulls,https://www.spotrac.com/nba/chicago-bulls/yearly,PG,27,$8000000,$8000000,UFA,,,
-Tre Mann,https://www.spotrac.com/nba/player/_/id/74125/tre-mann,tre-mann,Charlotte Hornets,https://www.spotrac.com/nba/charlotte-hornets/yearly,PG,25,$8000000,$8000000,UFA,,,
 Tre Mann,https://www.spotrac.com/nba/player/_/id/74125/tre-mann,tre-mann,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,PG,25,$8000000,$8000000,UFA,,,
 Trendon Watford,https://www.spotrac.com/nba/player/_/id/74232/trendon-watford,trendon-watford,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,PF,26,$2449421,UFA,,,,
 Trevon Brazile,https://www.spotrac.com/nba/player/_/id/91785/trevon-brazile,trevon-brazile,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,PF,24,$1357763,$2294370,$2694363,$2918152,RFA,

--- a/data/spotrac_contracts.csv
+++ b/data/spotrac_contracts.csv
@@ -310,6 +310,7 @@ Khaman Maluach,https://www.spotrac.com/nba/player/_/id/98606/khaman-maluach,kham
 Khris Middleton,https://www.spotrac.com/nba/player/_/id/10864/khris-middleton,khris-middleton,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,SF,35,$5591122,$5870678,$6150234,UFA,,
 Kingston Flemings,https://www.spotrac.com/nba/player/_/id/107923/kingston-flemings,kingston-flemings,Atlanta Hawks,https://www.spotrac.com/nba/atlanta-hawks/yearly,PG,20,$7348680,$7716120,$8083680,$10282441,RFA,
 K.J. Simpson,https://www.spotrac.com/nba/player/_/id/91788/kj-simpson,kj-simpson,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,PG,24,Two-Way,,,,,Kyle
+Klay Thompson,https://www.spotrac.com/nba/player/_/id/8062/klay-thompson,klay-thompson,Miami Heat,https://www.spotrac.com/nba/miami-heat/yearly,SG,36,$6341463,$6658537,UFA,,,
 Koa Peat,https://www.spotrac.com/nba/player/_/id/107938/koa-peat,koa-peat,Phoenix Suns,https://www.spotrac.com/nba/phoenix-suns/yearly,PF,20,$2926800,$3073080,$3219840,$5811811,RFA,
 Kobe Brown,https://www.spotrac.com/nba/player/_/id/84464/kobe-brown,kobe-brown,Indiana Pacers,https://www.spotrac.com/nba/indiana-pacers/yearly,PF,27,Two-Way,,,,,
 Kobe Bufkin,https://www.spotrac.com/nba/player/_/id/82271/kobe-bufkin,kobe-bufkin,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,PG,23,$0,,,,,

--- a/data/spotrac_contracts.csv
+++ b/data/spotrac_contracts.csv
@@ -55,6 +55,7 @@ Brandin Podziemski,https://www.spotrac.com/nba/player/_/id/84438/brandin-podziem
 Brandon Ingram,https://www.spotrac.com/nba/player/_/id/20207/brandon-ingram,brandon-ingram,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,SF,29,$40000000,$41904762,UFA,,,Brandon
 Brandon Ingram,https://www.spotrac.com/nba/player/_/id/20207/brandon-ingram,brandon-ingram,Toronto Raptors,https://www.spotrac.com/nba/toronto-raptors/yearly,SF,29,$40000000,$41904762,UFA,,,Brandon
 Brandon Miller,https://www.spotrac.com/nba/player/_/id/82197/brandon-miller,brandon-miller,Charlotte Hornets,https://www.spotrac.com/nba/charlotte-hornets/yearly,SF,24,$15104626,RFA,,,,Sam
+Brandon Williams,https://www.spotrac.com/nba/player/_/id/75136/brandon-williams,brandon-williams,Dallas Mavericks,https://www.spotrac.com/nba/dallas-mavericks/yearly,PG,27,$2449421,UFA,,,,
 Brayden Burries,https://www.spotrac.com/nba/player/_/id/107926/brayden-burries,brayden-burries,Milwaukee Bucks,https://www.spotrac.com/nba/milwaukee-bucks/yearly,SG,21,$6417360,$6738000,$7058520,$8999614,RFA,
 Brice Sensabaugh,https://www.spotrac.com/nba/player/_/id/82213/brice-sensabaugh,brice-sensabaugh,Utah Jazz,https://www.spotrac.com/nba/utah-jazz/yearly,SF,23,$4862237,RFA,,,,Brian
 Bronny James,https://www.spotrac.com/nba/player/_/id/92960/bronny-james,bronny-james,Los Angeles Lakers,https://www.spotrac.com/nba/los-angeles-lakers/yearly,PG,22,$2296271,$2486995,UFA,,,
@@ -310,7 +311,7 @@ Khaman Maluach,https://www.spotrac.com/nba/player/_/id/98606/khaman-maluach,kham
 Khris Middleton,https://www.spotrac.com/nba/player/_/id/10864/khris-middleton,khris-middleton,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,SF,35,$5591122,$5870678,$6150234,UFA,,
 Kingston Flemings,https://www.spotrac.com/nba/player/_/id/107923/kingston-flemings,kingston-flemings,Atlanta Hawks,https://www.spotrac.com/nba/atlanta-hawks/yearly,PG,20,$7348680,$7716120,$8083680,$10282441,RFA,
 K.J. Simpson,https://www.spotrac.com/nba/player/_/id/91788/kj-simpson,kj-simpson,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,PG,24,Two-Way,,,,,Kyle
-Klay Thompson,https://www.spotrac.com/nba/player/_/id/8062/klay-thompson,klay-thompson,Miami Heat,https://www.spotrac.com/nba/miami-heat/yearly,SG,36,$6341463,$6658537,UFA,,,
+Klay Thompson,https://www.spotrac.com/nba/player/_/id/8062/klay-thompson,klay-thompson,Miami Heat,https://www.spotrac.com/nba/miami-heat/yearly,SG,36,$5600000,$5880000,UFA,,,
 Koa Peat,https://www.spotrac.com/nba/player/_/id/107938/koa-peat,koa-peat,Phoenix Suns,https://www.spotrac.com/nba/phoenix-suns/yearly,PF,20,$2926800,$3073080,$3219840,$5811811,RFA,
 Kobe Brown,https://www.spotrac.com/nba/player/_/id/84464/kobe-brown,kobe-brown,Indiana Pacers,https://www.spotrac.com/nba/indiana-pacers/yearly,PF,27,Two-Way,,,,,
 Kobe Bufkin,https://www.spotrac.com/nba/player/_/id/82271/kobe-bufkin,kobe-bufkin,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,PG,23,$0,,,,,


### PR DESCRIPTION
DeMar DeRozan (SF) - Agreed to a 1 year $3.88 million contract with Denver Nuggets (DEN)
Klay Thompson (SG) - Signed to a 2 year $11.48 million contract with Miami Heat (MIA) - includes 2027-28 Player Option