### PR TITLE
Added Bennedict Mathurin (Efrain), Jonathan Kuminga

### DIFF
--- a/data/contract_types.csv
+++ b/data/contract_types.csv
@@ -37,6 +37,7 @@ Bam Adebayo,https://www.spotrac.com/nba/player/_/id/23609/bam-adebayo,bam-adebay
 Baylor Scheierman,https://www.spotrac.com/nba/player/_/id/91780/baylor-scheierman,baylor-scheierman,Rookie Scale Exception,"Round 1 (#30 overall), 2024"
 Ben Saraf,https://www.spotrac.com/nba/player/_/id/98626/ben-saraf,ben-saraf,Rookie Scale Exception,"Round 1 (#26 overall), 2025"
 Ben Sheppard,https://www.spotrac.com/nba/player/_/id/84440/ben-sheppard,ben-sheppard,Rookie Scale Exception,"Round 1 (#26 overall), 2023"
+Bennedict Mathurin,https://www.spotrac.com/nba/player/_/id/78115/bennedict-mathurin,bennedict-mathurin,Non-Taxpayer MLE,"Round 1 (#6 overall), 2022"
 Bennett Stirtz,https://www.spotrac.com/nba/player/_/id/107939/bennett-stirtz,bennett-stirtz,Rookie Scale Exception,"Round 1 (#16 overall), 2026"
 Bilal Coulibaly,https://www.spotrac.com/nba/player/_/id/82317/bilal-coulibaly,bilal-coulibaly,Rookie Scale Exception,"Round 1 (#7 overall), 2023"
 Bobby Portis,https://www.spotrac.com/nba/player/_/id/17850/bobby-portis,bobby-portis,Bird Rights,"Round 1 (#22 overall), 2015"
@@ -143,6 +144,7 @@ Fred VanVleet,https://www.spotrac.com/nba/player/_/id/20778/fred-vanvleet,fred-v
 Gary Harris,https://www.spotrac.com/nba/player/_/id/15371/gary-harris,gary-harris,Minimum,"Round 1 (#19 overall), 2014"
 Gary Payton II,https://www.spotrac.com/nba/player/_/id/20272/gary-payton-ii,gary-payton,Minimum,"Undrafted, HOU, 2016"
 Gary Trent Jr.,https://www.spotrac.com/nba/player/_/id/27003/gary-trent-jr,gary-trent,Early Bird Rights,"Round 2 (#37 overall), 2018"
+Georges Niang,https://www.spotrac.com/nba/player/_/id/20256/georges-niang,georges-niang,Minimum,"Round 2 (#50 overall), 2016"
 G.G. Jackson,https://www.spotrac.com/nba/player/_/id/85972/gg-jackson,gg-jackson,Non-Taxpayer MLE,"Round 2 (#45 overall), 2023"
 Giannis Antetokounmpo,https://www.spotrac.com/nba/player/_/id/13328/giannis-antetokounmpo,giannis-antetokounmpo,Bird Rights,"Round 1 (#15 overall), 2013"
 Goga Bitadze,https://www.spotrac.com/nba/player/_/id/31575/goga-bitadze,goga-bitadze,Early Bird Rights,"Round 1 (#18 overall), 2019"
@@ -219,6 +221,7 @@ John Konchar,https://www.spotrac.com/nba/player/_/id/32170/john-konchar,john-kon
 Johni Broome,https://www.spotrac.com/nba/player/_/id/98634/johni-broome,johni-broome,Second Round Exception,"Round 2 (#35 overall), 2025"
 Johnny Furphy,https://www.spotrac.com/nba/player/_/id/91768/johnny-furphy,johnny-furphy,Second Round Exception,"Round 2 (#35 overall), 2024"
 Jonathan Isaac,https://www.spotrac.com/nba/player/_/id/23601/jonathan-isaac,jonathan-isaac,Minimum,"Round 1 (#6 overall), 2017"
+Jonathan Kuminga,https://www.spotrac.com/nba/player/_/id/74114/jonathan-kuminga,jonathan-kuminga,Taxpayer MLE,"Round 1 (#7 overall), 2021"
 Jordan Clarkson,https://www.spotrac.com/nba/player/_/id/15398/jordan-clarkson,jordan-clarkson,Minimum,"Round 2 (#46 overall), 2014"
 Jordan Goodwin,https://www.spotrac.com/nba/player/_/id/74333/jordan-goodwin,jordan-goodwin,Early Bird Rights,Kevin Martin
 Jordan Hawkins,https://www.spotrac.com/nba/player/_/id/82208/jordan-hawkins,jordan-hawkins,Rookie Scale Exception,"Round 1 (#14 overall), 2023"

--- a/data/sportsws_positions.csv
+++ b/data/sportsws_positions.csv
@@ -90,7 +90,7 @@ B. McLemore,https://sports.ws/nba/ben-mclemore,ben-mclemore,G,
 B. Saraf,https://sports.ws/nba/ben-saraf,ben-saraf,G,B-Har
 B. Sheppard,https://sports.ws/nba/ben-sheppard,ben-sheppard,G,
 B. Simmons,https://sports.ws/nba/ben-simmons,ben-simmons,G,
-B. Mathurin,https://sports.ws/nba/bennedict-mathurin,bennedict-mathurin,F,
+B. Mathurin,https://sports.ws/nba/bennedict-mathurin,bennedict-mathurin,F,Efrain
 B. Stirtz,https://sports.ws/nba/bennett-stirtz,bennett-stirtz,G,
 B. Mbeng,https://sports.ws/nba/bez-meng,bez-meng,G,
 B. Coulibaly,https://sports.ws/nba/bilal-coulibaly,bilal-coulibaly,F,Brandon

--- a/data/spotrac_contracts.csv
+++ b/data/spotrac_contracts.csv
@@ -42,6 +42,7 @@ Bam Adebayo,https://www.spotrac.com/nba/player/_/id/23609/bam-adebayo,bam-adebay
 Baylor Scheierman,https://www.spotrac.com/nba/player/_/id/91780/baylor-scheierman,baylor-scheierman,Boston Celtics,https://www.spotrac.com/nba/boston-celtics/yearly,SG,26,$2744040,$4952993,RFA,,,
 Ben Saraf,https://www.spotrac.com/nba/player/_/id/98626/ben-saraf,ben-saraf,Brooklyn Nets,https://www.spotrac.com/nba/brooklyn-nets/yearly,PG,20,$3028560,$3172920,$5720776,RFA,,B-Har
 Ben Sheppard,https://www.spotrac.com/nba/player/_/id/84440/ben-sheppard,ben-sheppard,Indiana Pacers,https://www.spotrac.com/nba/indiana-pacers/yearly,SF,25,$5031669,RFA,,,,
+Bennedict Mathurin,https://www.spotrac.com/nba/player/_/id/78115/bennedict-mathurin,bennedict-mathurin,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,SG,24,$7804878,$8195122,UFA,,,Efrain
 Bennett Stirtz,https://www.spotrac.com/nba/player/_/id/107939/bennett-stirtz,bennett-stirtz,Oklahoma City Thunder,https://www.spotrac.com/nba/oklahoma-city-thunder/yearly,PG,23,$4717320,$4953240,$5189400,$7960540,RFA,
 Bilal Coulibaly,https://www.spotrac.com/nba/player/_/id/82317/bilal-coulibaly,bilal-coulibaly,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,SF,22,$9240012,RFA,,,,Brandon
 Blake Hinson,https://www.spotrac.com/nba/player/_/id/94488/blake-hinson,blake-hinson,Utah Jazz,https://www.spotrac.com/nba/utah-jazz/yearly,SG,27,Two-Way,,,,,
@@ -62,6 +63,7 @@ Bronny James,https://www.spotrac.com/nba/player/_/id/92960/bronny-james,bronny-j
 Brook Lopez,https://www.spotrac.com/nba/player/_/id/6136/brook-lopez,brook-lopez,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,C,38,$9187500,UFA,,,,
 Brooks Barnhizer,https://www.spotrac.com/nba/player/_/id/99258/brooks-barnhizer,brooks-barnhizer,Oklahoma City Thunder,https://www.spotrac.com/nba/oklahoma-city-thunder/yearly,SF,24,Two-Way,,,,,
 Bruce Thornton,https://www.spotrac.com/nba/player/_/id/108556/bruce-thornton,bruce-thornton,Houston Rockets,https://www.spotrac.com/nba/houston-rockets/yearly,PG,23,$1357763,$2294370,$2694363,$2918152,UFA,
+Bryce Hopkins,https://www.spotrac.com/nba/player/_/id/108437/bryce-hopkins,bryce-hopkins,Denver Nuggets,https://www.spotrac.com/nba/denver-nuggets/yearly,F,25,Two-Way,,,,,
 Bryce McGowens,https://www.spotrac.com/nba/player/_/id/78140/bryce-mcgowens,bryce-mcgowens,New Orleans Pelicans,https://www.spotrac.com/nba/new-orleans-pelicans/yearly,SG,24,$2584539,$2934742,UFA,,,
 Bub Carrington,https://www.spotrac.com/nba/player/_/id/91766/bub-carrington,bub-carrington,Washington Wizards,https://www.spotrac.com/nba/washington-wizards/yearly,PG,21,$4900560,$7257730,RFA,,,Stein
 Buddy Hield,https://www.spotrac.com/nba/player/_/id/20211/buddy-hield,buddy-hield,Atlanta Hawks,https://www.spotrac.com/nba/atlanta-hawks/yearly,SG,34,$9658536,$10097560,UFA,,,John
@@ -166,6 +168,7 @@ Fred VanVleet,https://www.spotrac.com/nba/player/_/id/20778/fred-vanvleet,fred-v
 Gary Harris,https://www.spotrac.com/nba/player/_/id/15371/gary-harris,gary-harris,Detroit Pistons,https://www.spotrac.com/nba/detroit-pistons/yearly,SG,32,$3815861,UFA,,,,
 Gary Payton II,https://www.spotrac.com/nba/player/_/id/20272/gary-payton-ii,gary-payton,Golden State Warriors,https://www.spotrac.com/nba/golden-state-warriors/yearly,PG,34,$2449421,UFA,,,,
 Gary Trent Jr.,https://www.spotrac.com/nba/player/_/id/27003/gary-trent-jr,gary-trent,Milwaukee Bucks,https://www.spotrac.com/nba/milwaukee-bucks/yearly,SG,28,$15200000,$16400000,$16400000,$16000000,UFA,
+Georges Niang,https://www.spotrac.com/nba/player/_/id/20256/georges-niang,georges-niang,Golden State Warriors,https://www.spotrac.com/nba/golden-state-warriors/yearly,PF,33,$2449421,UFA,,,,
 G.G. Jackson,https://www.spotrac.com/nba/player/_/id/85972/gg-jackson,gg-jackson,Memphis Grizzlies,https://www.spotrac.com/nba/memphis-grizzlies/yearly,PF,22,$2406205,UFA,,,,B-Har
 Giannis Antetokounmpo,https://www.spotrac.com/nba/player/_/id/13328/giannis-antetokounmpo,giannis-antetokounmpo,Miami Heat,https://www.spotrac.com/nba/miami-heat/yearly,PF,32,$58456566,$62786682,UFA,,,B-Har
 Goga Bitadze,https://www.spotrac.com/nba/player/_/id/31575/goga-bitadze,goga-bitadze,Orlando Magic,https://www.spotrac.com/nba/orlando-magic/yearly,C,27,$7608696,UFA,,,,
@@ -186,7 +189,7 @@ Isaac Jones,https://www.spotrac.com/nba/player/_/id/94481/isaac-jones,isaac-jone
 Isaac Okoro,https://www.spotrac.com/nba/player/_/id/70647/isaac-okoro,isaac-okoro,Chicago Bulls,https://www.spotrac.com/nba/chicago-bulls/yearly,SG,26,$11814814,UFA,,,,
 Isaiah Collier,https://www.spotrac.com/nba/player/_/id/91753/isaiah-collier,isaiah-collier,Utah Jazz,https://www.spotrac.com/nba/utah-jazz/yearly,PG,22,$2763960,$4988948,RFA,,,Andrew
 Isaiah Crawford,https://www.spotrac.com/nba/player/_/id/94482/isaiah-crawford,isaiah-crawford,Houston Rockets,https://www.spotrac.com/nba/houston-rockets/yearly,G,25,$2449421,$2664401,$2888193,$3272766,UFA,
-Isaiah Evans,https://www.spotrac.com/nba/player/_/id/107937/isaiah-evans,isaiah-evans,Minnesota Timberwolves,https://www.spotrac.com/nba/minnesota-timberwolves/yearly,SG,21,$0,$2294370,$2694363,$2918152,UFA,
+Isaiah Evans,https://www.spotrac.com/nba/player/_/id/107937/isaiah-evans,isaiah-evans,Minnesota Timberwolves,https://www.spotrac.com/nba/minnesota-timberwolves/yearly,SG,21,$1357763,$2294370,$2694363,$2918152,UFA,
 Isaiah Hartenstein,https://www.spotrac.com/nba/player/_/id/23644/isaiah-hartenstein,isaiah-hartenstein,Oklahoma City Thunder,https://www.spotrac.com/nba/oklahoma-city-thunder/yearly,C,28,$23148148,$25000000,$26851852,UFA,,
 Isaiah Jackson,https://www.spotrac.com/nba/player/_/id/74129/isaiah-jackson,isaiah-jackson,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,PF,25,$7000000,$6400000,UFA,,,
 Isaiah Joe,https://www.spotrac.com/nba/player/_/id/70691/isaiah-joe,isaiah-joe,Detroit Pistons,https://www.spotrac.com/nba/detroit-pistons/yearly,SG,27,$11323006,$11323006,UFA,,,
@@ -260,6 +263,7 @@ John Tonje,https://www.spotrac.com/nba/player/_/id/99266/john-tonje,john-tonje,P
 Johni Broome,https://www.spotrac.com/nba/player/_/id/98634/johni-broome,johni-broome,LA Clippers,https://www.spotrac.com/nba/la-clippers/yearly,C,24,$2150917,$2525901,$2735698,UFA,,
 Johnny Furphy,https://www.spotrac.com/nba/player/_/id/91768/johnny-furphy,johnny-furphy,Indiana Pacers,https://www.spotrac.com/nba/indiana-pacers/yearly,SG,22,$2296271,$2486995,UFA,,,
 Jonathan Isaac,https://www.spotrac.com/nba/player/_/id/23601/jonathan-isaac,jonathan-isaac,Orlando Magic,https://www.spotrac.com/nba/orlando-magic/yearly,PF,29,$2449421,UFA,,,,
+Jonathan Kuminga,https://www.spotrac.com/nba/player/_/id/74114/jonathan-kuminga,jonathan-kuminga,Minnesota Timberwolves,https://www.spotrac.com/nba/minnesota-timberwolves/yearly,PF,24,$6064000,$6367200,UFA,,,
 Jonathan Mogbo,https://www.spotrac.com/nba/player/_/id/92956/jonathan-mogbo,jonathan-mogbo,Sacramento Kings,https://www.spotrac.com/nba/sacramento-kings/yearly,C,25,Two-Way,Two-Way,,,,
 Jordan Clarkson,https://www.spotrac.com/nba/player/_/id/15398/jordan-clarkson,jordan-clarkson,New York Knicks,https://www.spotrac.com/nba/new-york-knicks/yearly,SG,34,$2449421,UFA,,,,
 Jordan Goodwin,https://www.spotrac.com/nba/player/_/id/74333/jordan-goodwin,jordan-goodwin,Phoenix Suns,https://www.spotrac.com/nba/phoenix-suns/yearly,PG,28,$5864198,$6333333,$6802469,UFA,UFA,
@@ -427,6 +431,7 @@ Quadir Copeland,https://www.spotrac.com/nba/player/_/id/108972/quadir-copeland,q
 Quentin Grimes,https://www.spotrac.com/nba/player/_/id/74132/quentin-grimes,quentin-grimes,Los Angeles Lakers,https://www.spotrac.com/nba/los-angeles-lakers/yearly,SG,26,$13953489,$14651163,$15348837,$16046511,UFA,
 Quenton Jackson,https://www.spotrac.com/nba/player/_/id/79955/quenton-jackson,quenton-jackson,Indiana Pacers,https://www.spotrac.com/nba/indiana-pacers/yearly,G,28,$2584539,$2934742,UFA,,,
 Quinten Post,https://www.spotrac.com/nba/player/_/id/93959/quinten-post,quinten-post,Memphis Grizzlies,https://www.spotrac.com/nba/memphis-grizzlies/yearly,C,26,$9000000,$8550000,$8550000,UFA,,Robert
+Rafael Castro,https://www.spotrac.com/nba/player/_/id/110011/rafael-castro,rafael-castro,Houston Rockets,https://www.spotrac.com/nba/houston-rockets/yearly,C,23,Two-Way,,,,,
 Rasheer Fleming,https://www.spotrac.com/nba/player/_/id/98617/rasheer-fleming,rasheer-fleming,Phoenix Suns,https://www.spotrac.com/nba/phoenix-suns/yearly,PF,22,$2150917,$2525901,$2735698,UFA,,
 Rayan Rupert,https://www.spotrac.com/nba/player/_/id/82212/rayan-rupert,rayan-rupert,Philadelphia 76ers,https://www.spotrac.com/nba/philadelphia-76ers/yearly,SG,22,Two-Way,,,,,
 RayJ Dennis,https://www.spotrac.com/nba/player/_/id/95567/rayj-dennis,rayj-dennis,Atlanta Hawks,https://www.spotrac.com/nba/atlanta-hawks/yearly,PG,25,Two-Way,,,,,


### PR DESCRIPTION
Added Bennedict Mathurin (Efrain), Jonathan Kuminga, Rafael Castro. Updated Isaiah Evans.

Bennedict Mathurin (SG) (Efrain) - Agreed to a 2 year $16 million contract with New Orleans Pelicans (NOP) - includes 2027-28 Player Option

Jonathan Kuminga (PF) - Signed a 2 year $12.43 million with Minnesota Timberwolves (MIN) - includes 2027-28 Player Option